### PR TITLE
Less fragile protocol, build fixes, pretty-printing

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.8.21"
+    kotlin("jvm")
     kotlin("plugin.serialization") version "1.8.21"
     application
 }
@@ -35,7 +35,7 @@ tasks.test {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "17"
 }
 
 application {

--- a/client/src/main/kotlin/Main.kt
+++ b/client/src/main/kotlin/Main.kt
@@ -52,7 +52,7 @@ class DevClientMain : CliktCommand() {
                 if (message.equals("exit", true)) return@launch
                 val newId = uidGenerator.generate(5)
                 val idWithReject = if (message == "reject" || message == "r") "-$newId" else newId
-                val updateDescriptor = UpdateDescriptor(name, "", idWithReject, UpdateStatus.LOCAL)
+                val updateDescriptor = UpdateDescriptor(name, "", idWithReject, UpdateStatus.LOCAL, message)
                 updateInputChannel.send(updateDescriptor)
             }
         }

--- a/client/src/main/kotlin/client/Client.kt
+++ b/client/src/main/kotlin/client/Client.kt
@@ -73,30 +73,35 @@ class Client(
             UpdateStatus.LOCAL -> {
                 LOG.info("...local update")
                 val realUpdate = update.copy(baseId = baseId())
-                database.apply(realUpdate)
                 unconfirmedUpdates.add(realUpdate)
                 runBlocking { serverChannel.send(realUpdate) }
             }
 
             UpdateStatus.COMMIT -> {
-                if (update.author == name) {
-                    LOG.info("...confirmation from server")
-                    if (update.id == unconfirmedUpdates.getOrNull(0)?.id) {
-                        LOG.info("...confirmed ${update.id}")
-                        unconfirmedUpdates.removeAt(0)
+                if (update.baseId == baseId()) {
+                    if (update.author == name) {
+                        LOG.info("...confirmation from server")
+                        if (update.id == unconfirmedUpdates.firstOrNull()?.id) {
+                            LOG.info("...confirmed ${update.id}")
+                            database.apply(unconfirmedUpdates.removeFirst())
+                        } else {
+                            LOG.info(
+                                "...ignoring, id ${update.id} doesn't match last unconfirmed update id " +
+                                    "${unconfirmedUpdates.getOrNull(0)?.id}"
+                            )
+                        }
                     } else {
-                        LOG.info("...ignoring, id ${update.id} doesn't match last unconfirmed update id " +
-                                 "${unconfirmedUpdates.getOrNull(0)?.id}")
+                        LOG.info("...applying")
+                        database.apply(update)
                     }
-                } else if (update.baseId == baseId()) {
-                    LOG.info("...applying")
-                    database.apply(update)
-                } else if (update.id !in appliedUpdates) {
-                    LOG.info("...can't apply")
-                    // The client diverged from the server and needs to synchronize
-                    synchronize()
                 } else {
-                    LOG.info("...already applied")
+                    if (update.id !in appliedUpdates) {
+                        LOG.info("...can't apply")
+                        // The client diverged from the server and needs to synchronize
+                        synchronize()
+                    } else {
+                        LOG.info("...already applied")
+                    }
                 }
             }
             // The server rejected this client's update.
@@ -115,7 +120,10 @@ class Client(
             val response = client.synchronize(unconfirmedUpdates)
             unconfirmedUpdates.clear()
             loadDatabase(response.database)
-            LOG.info("Synchronization response: $response")
+            println("""Database after sync:
+                        |-----------------------------
+                        |${database.toPrettyString()}
+                    """.trimMargin())
             response
             // TODO: In GanttProject prompt the user to do something if the updates where not committed
         } else {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.8.21"
+    kotlin("jvm")
     kotlin("plugin.serialization") version "1.8.21"
     application
 }
@@ -32,7 +32,7 @@ tasks.test {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "17"
 }
 
 application {

--- a/common/src/main/kotlin/common/DataClasses.kt
+++ b/common/src/main/kotlin/common/DataClasses.kt
@@ -12,7 +12,8 @@ data class UpdateDescriptor(
     val author: String,
     val baseId: String,
     val id: String,
-    val status: UpdateStatus
+    val status: UpdateStatus,
+    val value: String
 )
 
 @Serializable

--- a/common/src/main/kotlin/common/DatabaseMock.kt
+++ b/common/src/main/kotlin/common/DatabaseMock.kt
@@ -8,9 +8,16 @@ data class DatabaseMock(
 ) {
     fun apply(updateDescriptor: UpdateDescriptor) {
         history.add(updateDescriptor)
+        println("""Applied update ${updateDescriptor.id}
+            |--------------------------
+            |${toPrettyString()}
+            |--------------------------
+        """.trimMargin())
     }
 
     fun lastUpdate() = history.last()
 
     fun data() = history.toList()
+
+    fun toPrettyString() = history.joinToString(separator = "\n") { "#${it.baseId}(${it.author}): ${it.value}" }
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.8.21"
+    kotlin("jvm")
     kotlin("plugin.serialization") version "1.8.21"
     application
 }
@@ -28,7 +28,7 @@ tasks.test {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "17"
 }
 
 application {

--- a/server/src/main/kotlin/server/Server.kt
+++ b/server/src/main/kotlin/server/Server.kt
@@ -18,7 +18,7 @@ class Server(
         Executors.newSingleThreadExecutor().asCoroutineDispatcher()
     )
 
-    val database = DatabaseMock().apply { apply(UpdateDescriptor("server", "", "init", UpdateStatus.COMMIT)) }
+    val database = DatabaseMock().apply { apply(UpdateDescriptor("server", "", "init", UpdateStatus.COMMIT, "")) }
 
     fun start() {
         updateInputScope.launch {


### PR DESCRIPTION
Less fragile protocol implementation:
- we do not apply local updates to the database until they are committed on the server
- when a new update arrives, we first check if its base id matches the local one

